### PR TITLE
Add style for families list table

### DIFF
--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -1,32 +1,27 @@
 table {
-  display: flex;
-  flex-flow: column nowrap;
-  font-size: .8em;
-  margin: 0.5em;
-  line-height: 1.5;
-  flex: 1 1 auto;
+  border-collapse: collapse;
+  margin: 20px auto;
+  width: 85%;
+}
+
+td, th {
+  border: 5px;
+  padding-bottom: 5px;
+  padding-left: 5px;
+  padding-right: 5px;
+  text-align: center;
+  word-wrap: break-word;
 }
 
 th {
-  font-weight: 700;
-}
-
-th > td {
-  align-items: center;
-  justify-content: center;
-  white-space: normal;
-}
-
-tr {
-  width: 100%;
+  border-bottom: $border;
 }
 
 td {
-  justify-content: center;
-  min-width: 0px;
-  overflow: hidden;
-  padding: 0.5em;
-  text-overflow: ellipsis;
-  word-break: break-word;
-  white-space: nowrap;
+  border-bottom: $border;
+  padding-top: 15px;
+}
+
+tr:nth-child(even) {
+  background-color: $light-grey;
 }

--- a/app/assets/stylesheets/library/_colors.scss
+++ b/app/assets/stylesheets/library/_colors.scss
@@ -3,3 +3,4 @@ $offwhite: #f2f2f2;
 $light-blue: #DAE8ED;
 $blue: #B8D4DE;
 $grey: #d0d0d0;
+$light-grey: #f2f2f2;

--- a/app/assets/stylesheets/library/_library.scss
+++ b/app/assets/stylesheets/library/_library.scss
@@ -1,3 +1,2 @@
 @import "colors";
 @import "variables";
-@import "mixins";


### PR DESCRIPTION
This PR:
After I changed the table of the families list using proper table tag `<table>` `<th>` and `<td>` in this PR I restyle it without using flex box.

- An easer and more lean style at it.

- The output:

<img width="1278" alt="screen shot 2018-02-08 at 2 53 45 pm" src="https://user-images.githubusercontent.com/25237403/35954817-006b8e5c-0ce0-11e8-9f00-1e3cfe52e97b.png">


Trello Card:[ https://trello.com/c/S61uoKdR](url)