### PR TITLE
Change Rubocop implementations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,11 +56,14 @@ Style/NumericLiterals:
 Style/OneLineConditional:
   Enabled: false
 Style/SymbolArray:
-  Enabled: false
+  EnforcedStyle: brackets
 Style/StderrPuts:
   Exclude:
     - "bin/*"
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: consistent_comma
+  Enabled: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema.define(version: 20180125091555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
   create_table "families", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name", null: false


### PR DESCRIPTION
This PR just changes 2 Rubocop checks:

- no need for % symbol for arrays;

- Check for comma at the last argument of a list. 

Trello Card: [https://trello.com/c/ZcPbVOjF](url)