### PR TITLE
Add delete edit buttons on family index page

### DIFF
--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -13,12 +13,9 @@ td, th {
   word-wrap: break-word;
 }
 
-th {
-  border-bottom: $border;
-}
-
 td {
   border-bottom: $border;
+  border-top: $border;
   padding-top: 15px;
 }
 

--- a/app/assets/stylesheets/library/_colors.scss
+++ b/app/assets/stylesheets/library/_colors.scss
@@ -4,3 +4,4 @@ $light-blue: #DAE8ED;
 $blue: #B8D4DE;
 $grey: #d0d0d0;
 $light-grey: #f2f2f2;
+$light-green: #c2d6d6;

--- a/app/assets/stylesheets/patterns/_buttons.scss
+++ b/app/assets/stylesheets/patterns/_buttons.scss
@@ -9,8 +9,18 @@
   text-transform: uppercase;
 }
 
-.link_button{
+.link-button{
   appearance: button;
-  text-decoration: none;
   display: inline-block;
+  text-decoration: none;
+}
+
+td .list-button{
+  background: $light-green;
+  border-radius: 2px;
+  color: $dark-grey;
+  display: block;
+  font-size: 12px;
+  padding: 5px 10px;
+  text-transform: uppercase;
 }

--- a/app/views/families/_family.html.erb
+++ b/app/views/families/_family.html.erb
@@ -8,4 +8,6 @@
   <td><%= family.bus_driver %></td>
   <td><%= family.animals %></td>
   <td><%= family.active %></td>
+  <td><%= link_to t("families.index.destroy"), family_path(family), method: :delete, class: "list-button" %></td>
+  <td><%= link_to t("families.index.edit"), family_path(family), class: "list-button" %></td>
 </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,17 +17,19 @@ en:
         m: "Male"
   header:
     links:
-      home: Home Page
-      families: Families List
-      groups: Groups List
+      home: "Home Page"
+      families: "Families List"
+      groups: "Groups List"
       create_list: "Create a List"
   families:
     index:
       title: "Families"
       add_family: "Add a Family"
       submit: "Add"
+      destroy: "Delete"
+      edit: "Edit"
     new:
       title: "Add a family"
       submit: "Add"
     show:
-      title: Family details  
+      title: "Family details"


### PR DESCRIPTION
This PR add `delete` and `edit` button to each family in the families table list, the corresponding style and translations.

Below a screenshot of the new list:

![screen shot 2018-02-15 at 1 01 58 pm](https://user-images.githubusercontent.com/25237403/36237722-cac0c46c-1251-11e8-98d6-af35e236a086.png)
 