### PR TITLE
Update header and add trip style

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -8,7 +8,7 @@
   border: $border;
   list-style-type: none;
   margin: 0 auto;
-  max-width: 800px;
+  max-width: 30%;
   padding: 10px;
 }
 
@@ -24,10 +24,6 @@ label {
   max-width: 220px;
 }
 
-label + * {
-  flex: 1 0 220px;
-}
-
 span.error {
   color: red;
 }
@@ -35,4 +31,9 @@ span.error {
 #trip_end_date_3i,
 #trip_start_date_3i {
   max-width: fit-content;
+}
+
+.numeric {
+  border-radius: 10%;
+  max-width: 70px;
 }

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -22,3 +22,8 @@ td {
 tr:nth-child(even) {
   background-color: $light-grey;
 }
+
+.homepage{
+  margin-top: 15%;
+  width: 25%;
+}

--- a/app/assets/stylesheets/patterns/_buttons.scss
+++ b/app/assets/stylesheets/patterns/_buttons.scss
@@ -3,8 +3,10 @@
   border: none;
   border-radius: 2px;
   color: $offwhite;
+  display: block;
   font-size: 15px;
   letter-spacing: 0.009em;
+  margin: 10px;
   padding: 8px 16px;
   text-transform: uppercase;
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def show
+    render template: "pages/home"
+  end
+end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -10,7 +10,7 @@
       <%= link_to t("header.links.schools"), schools_path %>
     </li>
     <li>
-      <%= link_to t("header.links.create_list") %>
+      <%= link_to t("header.links.trips"), trips_path %>
     </li>
   </ul>
 </nav>

--- a/app/views/families/index.html.erb
+++ b/app/views/families/index.html.erb
@@ -1,6 +1,6 @@
 <p class="title"><%= t(".title") %></p>
+<%= link_to t(".add_family"), new_family_path, class: "link_button, button" %>
 <table>
   <%= render "families_table_header" %>
   <%= render @families %>
 </table>
-<%= link_to t(".add_family"), new_family_path, class: "link_button, button" %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,0 +1,18 @@
+
+<table class="homepage">
+  <tr>
+    <td>
+      <%= link_to t("families.new.title"), new_family_path %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= link_to t("schools.new.title"), new_school_path %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= link_to t("trips.new.title"), new_trip_path %>
+    </td>
+  </tr>
+</table>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -1,6 +1,6 @@
 <p class="title"><%= t(".title") %></p>
+<%= link_to t(".add_school"), new_school_path, class: "link_button, button" %>
 <table>
   <%= render "schools_table_header" %>
   <%= render @schools %>
 </table>
-<%= link_to t(".add_school"), new_school_path, class: "link_button, button" %>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -1,6 +1,6 @@
 <p class="title"><%= t(".title") %></p>
+<%= link_to t(".add_trip"), new_trip_path, class: "link_button, button" %>
 <table>
   <%= render "trips_table_header" %>
   <%= render @trips %>
 </table>
-<%= link_to t(".add_trip"), new_trip_path, class: "link_button, button" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,9 +42,9 @@ en:
   header:
     links:
       home: "Home Page"
-      families: "Families List"
-      schools: "Schools List"
-      create_list: "Create a List"
+      families: "Families"
+      schools: "Schools"
+      trips: "Trips"
   families:
     index:
       title: "Families"
@@ -65,9 +65,9 @@ en:
       submit: "Submit"
   schools:
     new:
-      title: "Add a new school"
+      title: "Add a school"
     index:
-      title: "Schools List"
+      title: "Schools"
       add_school: "Add a school"
       destroy: "Delete"
       edit: "Edit"
@@ -88,3 +88,5 @@ en:
     edit:
       title: "Edit trip"
       destroy: "delete"
+      title: "Trips"
+      add_trip: "Add a trip"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :families
   resources :schools, only: [:index, :new, :create, :edit, :update, :destroy]
   resources :trips, only: [:index, :new, :create, :edit, :update, :destroy]
+  resources :pages, only: [:show]
 
-  root "families#index"
+  root "pages#show"
 end


### PR DESCRIPTION
This PR:
- Update the header adding the link to trips;
- Change the header naming to be more consistent;
- Add a homepage with link to add a new family/school/trip with a basic style (maybe I will restyle it);

<img width="1262" alt="screen shot 2018-02-25 at 1 11 40 pm" src="https://user-images.githubusercontent.com/25237403/36637315-f173c2f6-1a2d-11e8-8b86-f80ed7902c3b.png">

- Change the width for total-girls/total_boys/.. in the trip/_form to be smaller;
<img width="886" alt="screen shot 2018-02-25 at 1 40 30 pm" src="https://user-images.githubusercontent.com/25237403/36637515-81f76492-1a31-11e8-8a1c-b71875ba2dee.png">

- Move the add family/school/trip buttons to be under the title instead of at the bottom of the page for a better usability (see pic below):
<img width="1271" alt="screen shot 2018-02-25 at 1 34 51 pm" src="https://user-images.githubusercontent.com/25237403/36637478-b4e2601a-1a30-11e8-8945-906715cb4c29.png">
